### PR TITLE
Multiple radiation types

### DIFF
--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -245,6 +245,8 @@ public class Radiation implements Listener {
     //
 
     public static class Config {
+        public static final String DEFAULT_ID = "default";
+
         private final String id;
         private final BarConfig bar;
         private final Iterable<PotionEffect> effects;
@@ -264,10 +266,8 @@ public class Radiation implements Listener {
                 section = new MemoryConfiguration();
             }
 
-            this.id = section.getName();
-            if (this.id.isEmpty()) {
-                throw new InvalidConfigurationException("Empty radiation ID given.");
-            }
+            String id = section.getName();
+            this.id = id.isEmpty() ? DEFAULT_ID : id;
 
             try {
                 this.bar = new BarConfig(section.getConfigurationSection("bar"));

--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -225,13 +225,13 @@ public class Radiation implements Listener {
      */
     public static class FlagMatcher implements WorldGuardMatcher {
         private final Flag<Boolean> isRadioactiveFlag;
-        private final Flag<String> radiationIdFlag;
-        private final Set<String> acceptedRadiationIds;
+        private final Flag<String> radiationTypeFlag;
+        private final Set<String> acceptedRadiationTypes;
 
-        public FlagMatcher(Flag<Boolean> isRadioactiveFlag, Flag<String> radiationIdFlag, Set<String> acceptedRadiationIds) {
+        public FlagMatcher(Flag<Boolean> isRadioactiveFlag, Flag<String> radiationTypeFlag, Set<String> acceptedRadiationTypes) {
             this.isRadioactiveFlag = Objects.requireNonNull(isRadioactiveFlag, "isRadioactiveFlag");
-            this.radiationIdFlag = Objects.requireNonNull(radiationIdFlag, "radiationIdFlag");
-            this.acceptedRadiationIds = Objects.requireNonNull(acceptedRadiationIds, "acceptedRadiationIds");
+            this.radiationTypeFlag = Objects.requireNonNull(radiationTypeFlag, "radiationTypeFlag");
+            this.acceptedRadiationTypes = Objects.requireNonNull(acceptedRadiationTypes, "acceptedRadiationTypes");
         }
 
         @Override
@@ -246,12 +246,12 @@ public class Radiation implements Listener {
                 return false;
             }
 
-            String radiationId = regions.queryValue(localPlayer, this.radiationIdFlag);
+            String radiationId = regions.queryValue(localPlayer, this.radiationTypeFlag);
             if (radiationId == null || radiationId.isEmpty()) {
                 radiationId = Config.DEFAULT_ID;
             }
 
-            return this.acceptedRadiationIds.contains(radiationId);
+            return this.acceptedRadiationTypes.contains(radiationId);
         }
     }
 

--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -121,10 +121,12 @@ public class Radiation implements Listener {
 
     private void broadcastEscape(Player player) {
         Objects.requireNonNull(player, "player");
-        logger.info("{} has escaped to radiation zone at {}", player.getName(), player.getLocation());
+
+        String radiationId = this.config.id();
+        logger.info("{} has escaped to \"{}\" radiation zone at {}", player.getName(), radiationId, player.getLocation());
 
         this.config.escapeMessage().ifPresent(rawMessage -> {
-            String message = ChatColor.RED + MessageFormat.format(rawMessage, player.getDisplayName() + ChatColor.RESET);
+            String message = ChatColor.RED + MessageFormat.format(rawMessage, player.getDisplayName() + ChatColor.RESET, radiationId);
             for (Player online : this.plugin.getServer().getOnlinePlayers()) {
                 if (online.canSee(player)) {
                     online.sendMessage(message);

--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -16,6 +16,7 @@
 
 package pl.craftserve.radiation;
 
+import com.google.common.base.Preconditions;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldguard.WorldGuard;
@@ -242,19 +243,28 @@ public class Radiation implements Listener {
     //
 
     public static class Config {
+        private final String id;
         private final BarConfig bar;
         private final Iterable<PotionEffect> effects;
         private final String escapeMessage;
 
-        public Config(BarConfig bar, Iterable<PotionEffect> effects, String escapeMessage) {
+        public Config(String id, BarConfig bar, Iterable<PotionEffect> effects, String escapeMessage) {
+            this.id = Objects.requireNonNull(id, "id");
             this.bar = Objects.requireNonNull(bar, "bar");
             this.effects = Objects.requireNonNull(effects, "effects");
             this.escapeMessage = escapeMessage;
+
+            Preconditions.checkArgument(!id.isEmpty(), "id cannot be empty");
         }
 
         public Config(ConfigurationSection section) throws InvalidConfigurationException {
             if (section == null) {
                 section = new MemoryConfiguration();
+            }
+
+            this.id = section.getName();
+            if (this.id.isEmpty()) {
+                throw new InvalidConfigurationException("Empty radiation ID given.");
             }
 
             try {
@@ -297,6 +307,10 @@ public class Radiation implements Listener {
 
             String escapeMessage = RadiationPlugin.colorize(section.getString("escape-message"));
             this.escapeMessage = escapeMessage != null && !escapeMessage.isEmpty() ? escapeMessage : null;
+        }
+
+        public String id() {
+            return this.id;
         }
 
         public BarConfig bar() {

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -281,9 +281,15 @@ public final class RadiationPlugin extends JavaPlugin {
         }
 
         if (protocol < 2) {
-            ConfigurationSection standardRadiation = section.getConfigurationSection("radiation");
+            MemoryConfiguration defaultRadiation = new MemoryConfiguration();
+
+            ConfigurationSection oldRadiation = section.getConfigurationSection("radiation");
+            if (oldRadiation != null) {
+                oldRadiation.getValues(true).forEach(defaultRadiation::set);
+            }
+
             section.set("radiation", null); // remove old section
-            section.set("radiation.standard", standardRadiation);
+            section.set("radiations.default", defaultRadiation);
         }
 
         return true;
@@ -382,11 +388,11 @@ public final class RadiationPlugin extends JavaPlugin {
 
                 ConfigurationSection radiationsSection = Objects.requireNonNull(section.getConfigurationSection("radiations"));
                 for (String key : radiationsSection.getKeys(false)) {
-                    if (!section.isConfigurationSection(key)) {
+                    if (!radiationsSection.isConfigurationSection(key)) {
                         throw new InvalidConfigurationException(key + " is not a radiation section.");
                     }
 
-                    radiations.add(new Radiation.Config(section.getConfigurationSection(key)));
+                    radiations.add(new Radiation.Config(radiationsSection.getConfigurationSection(key)));
                 }
 
                 this.radiations = Collections.unmodifiableCollection(radiations);

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -43,10 +43,13 @@ import pl.craftserve.radiation.nms.V1_14ToV1_15NmsBridge;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -155,7 +158,10 @@ public final class RadiationPlugin extends JavaPlugin {
         this.display.enable();
 
         this.activeRadiations.forEach((id, radiation) -> radiation.enable());
-        logger.info("Loaded and enabled {} radiation(s): {}", this.activeRadiations.size(), String.join(", ", this.activeRadiations.keySet()));
+
+        Set<String> radiationIds = new TreeSet<>(Comparator.naturalOrder());
+        radiationIds.addAll(this.activeRadiations.keySet());
+        logger.info("Loaded and enabled {} radiation(s): {}", this.activeRadiations.size(), String.join(", ", radiationIds));
 
         this.craftserveListener.enable();
         this.metricsHandler.start();

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -20,6 +20,7 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.flags.BooleanFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.StringFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
@@ -64,8 +65,10 @@ public final class RadiationPlugin extends JavaPlugin {
 
     private static final int CURRENT_PROTOCOL_VERSION = 2;
     private static final Flag<Boolean> RADIATION_FLAG = new BooleanFlag("radiation");
+    private static final Flag<String> RADIATION_ID_FLAG = new StringFlag("radiation-id");
 
     private Flag<Boolean> radiationFlag;
+    private Flag<String> radiationIdFlag;
     private RadiationNmsBridge radiationNmsBridge;
     private Config config;
 
@@ -99,7 +102,8 @@ public final class RadiationPlugin extends JavaPlugin {
             throw new IllegalStateException("Flag registry is not set! Plugin must shut down...");
         }
 
-        this.radiationFlag = this.getOrCreateRadiationFlag(flagRegistry);
+        this.radiationFlag = this.getOrCreateFlag(flagRegistry, RADIATION_FLAG);
+        this.radiationIdFlag = this.getOrCreateFlag(flagRegistry, RADIATION_ID_FLAG);
     }
 
     @Override
@@ -194,6 +198,10 @@ public final class RadiationPlugin extends JavaPlugin {
         return this.radiationFlag;
     }
 
+    public Flag<String> getRadiationIdFlag() {
+        return this.radiationIdFlag;
+    }
+
     public Config getPluginConfig() {
         return this.config;
     }
@@ -211,15 +219,16 @@ public final class RadiationPlugin extends JavaPlugin {
     }
 
     @SuppressWarnings("unchecked")
-    private Flag<Boolean> getOrCreateRadiationFlag(FlagRegistry flagRegistry) {
+    private <T> Flag<T> getOrCreateFlag(FlagRegistry flagRegistry, Flag<T> defaultFlag) {
         Objects.requireNonNull(flagRegistry, "flagRegistry");
+        Objects.requireNonNull(defaultFlag, "defaultFlag");
 
-        Flag<Boolean> flag = (Flag<Boolean>) flagRegistry.get(RADIATION_FLAG.getName());
+        Flag<T> flag = (Flag<T>) flagRegistry.get(defaultFlag.getName());
         if (flag != null) {
             return flag;
         }
 
-        flag = RADIATION_FLAG;
+        flag = defaultFlag;
         flagRegistry.register(flag);
         return flag;
     }

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -155,6 +155,7 @@ public final class RadiationPlugin extends JavaPlugin {
         this.display.enable();
 
         this.activeRadiations.forEach((id, radiation) -> radiation.enable());
+        logger.info("Loaded and enabled {} radiation(s): {}", this.activeRadiations.size(), String.join(", ", this.activeRadiations.keySet()));
 
         this.craftserveListener.enable();
         this.metricsHandler.start();

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -146,9 +146,10 @@ public final class RadiationPlugin extends JavaPlugin {
         this.display = new LugolsIodineDisplay(this, this.effect, this.config.lugolsIodineDisplay());
 
         for (Radiation.Config radiationConfig : this.config.radiations()) {
-            Radiation.Matcher matcher = new Radiation.FlagMatcher(this.radiationFlag);
-            Radiation radiation = new Radiation(this, matcher, radiationConfig);
-            this.activeRadiations.put(radiationConfig.id(), radiation);
+            String id = radiationConfig.id();
+            Radiation.Matcher matcher = new Radiation.FlagMatcher(this.radiationFlag, this.radiationIdFlag, Collections.singleton(id));
+
+            this.activeRadiations.put(id, new Radiation(this, matcher, radiationConfig));
         }
 
         RadiationCommandHandler radiationCommandHandler = new RadiationCommandHandler(this.radiationFlag, this.potion);

--- a/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
+++ b/src/main/java/pl/craftserve/radiation/RadiationPlugin.java
@@ -65,10 +65,10 @@ public final class RadiationPlugin extends JavaPlugin {
 
     private static final int CURRENT_PROTOCOL_VERSION = 2;
     private static final Flag<Boolean> RADIATION_FLAG = new BooleanFlag("radiation");
-    private static final Flag<String> RADIATION_ID_FLAG = new StringFlag("radiation-id");
+    private static final Flag<String> RADIATION_TYPE_FLAG = new StringFlag("radiation-type");
 
     private Flag<Boolean> radiationFlag;
-    private Flag<String> radiationIdFlag;
+    private Flag<String> radiationTypeFlag;
     private RadiationNmsBridge radiationNmsBridge;
     private Config config;
 
@@ -103,7 +103,7 @@ public final class RadiationPlugin extends JavaPlugin {
         }
 
         this.radiationFlag = this.getOrCreateFlag(flagRegistry, RADIATION_FLAG);
-        this.radiationIdFlag = this.getOrCreateFlag(flagRegistry, RADIATION_ID_FLAG);
+        this.radiationTypeFlag = this.getOrCreateFlag(flagRegistry, RADIATION_TYPE_FLAG);
     }
 
     @Override
@@ -147,7 +147,7 @@ public final class RadiationPlugin extends JavaPlugin {
 
         for (Radiation.Config radiationConfig : this.config.radiations()) {
             String id = radiationConfig.id();
-            Radiation.Matcher matcher = new Radiation.FlagMatcher(this.radiationFlag, this.radiationIdFlag, Collections.singleton(id));
+            Radiation.Matcher matcher = new Radiation.FlagMatcher(this.radiationFlag, this.radiationTypeFlag, Collections.singleton(id));
 
             this.activeRadiations.put(id, new Radiation(this, matcher, radiationConfig));
         }
@@ -199,8 +199,8 @@ public final class RadiationPlugin extends JavaPlugin {
         return this.radiationFlag;
     }
 
-    public Flag<String> getRadiationIdFlag() {
-        return this.radiationIdFlag;
+    public Flag<String> getRadiationTypeFlag() {
+        return this.radiationTypeFlag;
     }
 
     public Config getPluginConfig() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -39,42 +39,46 @@ lugols-iodine-potion:
   # Colorable broadcast message shown when a player consumes the potion, leave empty for no message.
   drink-message: '{0}&c drank {1}.'
 
-# Radiation zone options.
-radiation:
-  # Boss bar shown on the screen when a player is in the zone.
-  bar:
-    # Colorable title shown on the bar.
-    title: 'Radiation Zone'
-    # Color of the bar, possible values:
-    # blue, green, pink, purple, red, white, yellow
-    color: red
-    # Style of the bar, possible values:
-    # segmented_6, segmented_10, segmented_12, segmented_20, solid
-    style: solid
-    # Additional effects given for the player, possible values:
-    # create_fog, darken_sky, play_boss_music
-    flags: [darken_sky]
-  # Effects given in the radiation zone.
-  effects:
-    # Name of the effect. List of effect names is available here:
-    # https://minecraft.gamepedia.com/Status_effect#Effect_IDs
-    wither:
-      # Level of the effect, eg. level 5 gives Wither V effect.
-      level: 5
-      # Should this effect produce more, translucent, particles?
-      ambient: false
-      # Does this effect produce particles?
-      has-particles: false
-      # Does this effect give an icon?
-      has-icon: false
-    hunger:
-      # Level of the effect, eg. level 5 gives Wither V effect.
-      level: 1
-      # Should this effect produce more, translucent, particles?
-      ambient: false
-      # Does this effect produce particles?
-      has-particles: false
-      # Does this effect give an icon?
-      has-icon: false
-  # Colorable broadcast message shown when a player enters radiation zone, leave empty for no message/
-  escape-message: '{0}&c has escaped to radiation zone.'
+# Radiation zone options. You can define as many radiation types as you want.
+# Each one must have its own unique identifier, such as "default".
+# Use "radiation-id" flag to declare region a specific radiation type.
+radiations:
+  # The "default" radiation, used when "radiation-id" flag is not set.
+  default:
+    # Boss bar shown on the screen when a player is in the zone.
+    bar:
+      # Colorable title shown on the bar.
+      title: 'Radiation Zone'
+      # Color of the bar, possible values:
+      # blue, green, pink, purple, red, white, yellow
+      color: red
+      # Style of the bar, possible values:
+      # segmented_6, segmented_10, segmented_12, segmented_20, solid
+      style: solid
+      # Additional effects given for the player, possible values:
+      # create_fog, darken_sky, play_boss_music
+      flags: [darken_sky]
+    # Effects given in the radiation zone.
+    effects:
+      # Name of the effect. List of effect names is available here:
+      # https://minecraft.gamepedia.com/Status_effect#Effect_IDs
+      wither:
+        # Level of the effect, eg. level 5 gives Wither V effect.
+        level: 5
+        # Should this effect produce more, translucent, particles?
+        ambient: false
+        # Does this effect produce particles?
+        has-particles: false
+        # Does this effect give an icon?
+        has-icon: false
+      hunger:
+        # Level of the effect, eg. level 5 gives Wither V effect.
+        level: 1
+        # Should this effect produce more, translucent, particles?
+        ambient: false
+        # Does this effect produce particles?
+        has-particles: false
+        # Does this effect give an icon?
+        has-icon: false
+    # Colorable broadcast message shown when a player enters radiation zone, leave empty for no message.
+    escape-message: '{0}&c has escaped to radiation zone.'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Indicates version of this file, please don't touch!
-file-protocol-version-dont-touch: 1
+file-protocol-version-dont-touch: 2
 
 # Boss bar shown on the screen when player has lugol's iodine effect.
 lugols-iodine-bar:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -44,6 +44,7 @@ lugols-iodine-potion:
 # Use "radiation-type" flag to declare region a specific radiation type.
 radiations:
   # The "default" radiation, used when "radiation-type" flag is not set.
+  # It is recommended to not remove the "default" radiation.
   default:
     # Boss bar shown on the screen when a player is in the zone.
     bar:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,9 +41,9 @@ lugols-iodine-potion:
 
 # Radiation zone options. You can define as many radiation types as you want.
 # Each one must have its own unique identifier, such as "default".
-# Use "radiation-id" flag to declare region a specific radiation type.
+# Use "radiation-type" flag to declare region a specific radiation type.
 radiations:
-  # The "default" radiation, used when "radiation-id" flag is not set.
+  # The "default" radiation, used when "radiation-type" flag is not set.
   default:
     # Boss bar shown on the screen when a player is in the zone.
     bar:


### PR DESCRIPTION
People can now define different radiation types. Radiation types are declared in the config. Use `radiation-id` flag to declare region a specific region type, otherwise `default` radiation type will be used. 