### PR TITLE
Fixed broadcasting when entering zone

### DIFF
--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -104,14 +104,6 @@ public class Radiation implements Listener {
         Objects.requireNonNull(player, "player");
 
         boolean ok = this.affectedPlayers.add(player.getUniqueId());
-        if (ok && addBossBar) {
-            boolean contains = this.bossBar.getPlayers().contains(player);
-
-            if (!contains) {
-                this.addBossBar(player);
-                this.broadcastEscape(player);
-            }
-        }
 
         return ok;
     }
@@ -180,17 +172,22 @@ public class Radiation implements Listener {
                     boolean showBossBar = event.shouldShowWarning();
                     boolean cancel = event.isCancelled();
 
+                    boolean contains = bossBar.getPlayers().contains(player);
+
                     if (!cancel) {
                         for (PotionEffect effect : effects) {
                             player.addPotionEffect(effect, true);
                         }
 
                         addAffectedPlayer(player, showBossBar);
-                        return;
                     }
 
                     if (showBossBar) {
                         addBossBar(player);
+
+                        if (!contains) {
+                            broadcastEscape(player);
+                        }
                     } else {
                         removeBossBar(player);
                     }

--- a/src/main/java/pl/craftserve/radiation/Radiation.java
+++ b/src/main/java/pl/craftserve/radiation/Radiation.java
@@ -103,9 +103,7 @@ public class Radiation implements Listener {
     public boolean addAffectedPlayer(Player player, boolean addBossBar) {
         Objects.requireNonNull(player, "player");
 
-        boolean ok = this.affectedPlayers.add(player.getUniqueId());
-
-        return ok;
+        return this.affectedPlayers.add(player.getUniqueId());
     }
 
     private void addBossBar(Player player) {


### PR DESCRIPTION
Up to this point, a message of player entering zone was broadcasted only when player didn't drink a potion. There was no information about it when player already drank it.

This PR fixes it - now its broadcasted regardless of whether or not player had drunk a potion.